### PR TITLE
Incorrect file name on ConfigMap apply

### DIFF
--- a/chapters/13_redis_statefulset.md
+++ b/chapters/13_redis_statefulset.md
@@ -73,7 +73,7 @@ data:
 apply
 
 ```
-kubectl apply -f redis-svc.yml
+kubectl apply -f redis-cm.yml
 ```
 
 ### Redis initContainers


### PR DESCRIPTION
The config map is created with the name `redis-cm.yml` but the apply show `redis-svc.yml` from the above section.